### PR TITLE
Customize the navbar to use Bootstrap

### DIFF
--- a/src/elm/View/Page.elm
+++ b/src/elm/View/Page.elm
@@ -2,6 +2,7 @@ module View.Page exposing (ActivePage(..), layout)
 
 import Html exposing (..)
 import Route exposing (Route)
+import Html.Attributes exposing (id, class, href, placeholder, attribute, type_)
 
 
 type ActivePage
@@ -17,22 +18,35 @@ layout : ActivePage -> Html msg -> Html msg
 layout page content =
     div []
         [ viewHeader page
-        , div [] [ content ]
+        , div [ class "container-fluid" ] [ content ]
         , viewFooter
         ]
 
 
 viewHeader : ActivePage -> Html msg
 viewHeader page =
-    nav []
-        [ div []
-            [ a [ Route.href Route.Home ]
-                [ text "Home" ]
-            , text " | "
-            , a [ Route.href Route.About ]
-                [ text "About" ]
+    nav [ class "navbar navbar-expand-lg navbar-light bg-light" ]
+        [ a [ class "navbar-brand", href "#" ]
+            [ text "Elm" ]
+        , button [ attribute "aria-controls" "navbarSupportedContent", attribute "aria-expanded" "false", attribute "aria-label" "Toggle navigation", class "navbar-toggler", attribute "data-target" "#navbarSupportedContent", attribute "data-toggle" "collapse", type_ "button" ]
+            [ span [ class "navbar-toggler-icon" ]
+                []
             ]
-        , hr [] []
+        , div [ class "collapse navbar-collapse", id "navbarSupportedContent" ]
+            [ ul [ class "navbar-nav ml-auto" ]
+                [ li [ class "nav-item active" ]
+                    [ a [ class "nav-link", Route.href Route.Home ]
+                        [ text "Home "
+                        , span [ class "sr-only" ]
+                            [ text "(current)" ]
+                        ]
+                    ]
+                , li [ class "nav-item" ]
+                    [ a [ class "nav-link", Route.href Route.About ]
+                        [ text "About" ]
+                    ]
+                ]
+            ]
         ]
 
 


### PR DESCRIPTION
In order to demonstrate the use of Bootstrap, I designed the [header](https://github.com/GRoguelon/elm-webpack-4-starter/blob/e02db35a47b34b3dc0cec3ba63ca214788061000/src/elm/View/Page.elm#L27-L50) by using the Bootstrap NavBar.